### PR TITLE
memo_tagsテーブルにカラム追加

### DIFF
--- a/app/Models/MemoTag.php
+++ b/app/Models/MemoTag.php
@@ -8,6 +8,4 @@ use Illuminate\Database\Eloquent\Model;
 class MemoTag extends Model
 {
     use HasFactory;
-
-    public $timestamps = false;
 }

--- a/app/Repositories/MeMoTagRepository.php
+++ b/app/Repositories/MeMoTagRepository.php
@@ -22,13 +22,15 @@ class MemoTagRepository
     /**
      * insert memo tag
      *
+     * @param int $userId
      * @param int $memoId
      * @param int $tagId
      * @return void
      */
-    public function insertMemoTag(int $memoId, int $tagId): void
+    public function insertMemoTag(int $userId, int $memoId, int $tagId): void
     {
         $this->memoTag::insert([
+            'user_id' => $userId,
             'memo_id' => $memoId,
             'tag_id' => $tagId,
         ]);

--- a/app/Repositories/MemoTagRepositoryInterface.php
+++ b/app/Repositories/MemoTagRepositoryInterface.php
@@ -7,11 +7,12 @@ Interface MemoTagRepositoryInterface
     /**
      * insert memo tag
      *
+     * @param int $userId
      * @param int $memoId
      * @param int $tagId
      * @return void
      */
-    public function insertMemoTag(int $memoId, int $tagId): void;
+    public function insertMemoTag(int $userId, int $memoId, int $tagId): void;
 
     /**
      * delete memo tag

--- a/app/Services/TagService.php
+++ b/app/Services/TagService.php
@@ -58,19 +58,19 @@ class TagService implements TagServiceInterface
      * @param array|null $posts
      * @param int $memoId
      * @param bool $tagExists
-     * @param int $authId
+     * @param int $userId
      * @return void
      */
-    public function attachTagsToMemo(?array $posts, int $memoId, bool $tagExists, int $authId): void
+    public function attachTagsToMemo(?array $posts, int $memoId, bool $tagExists, int $userId): void
     {
         if (!empty($posts['new_tag']) && !$tagExists) {
-            $tagId = $this->tagRepository->insertTagGetId($posts['new_tag'], $authId);
-            $this->memoTagRepository->insertMemoTag($memoId, $tagId);
+            $tagId = $this->tagRepository->insertTagGetId($posts['new_tag'], $userId);
+            $this->memoTagRepository->insertMemoTag($userId, $memoId, $tagId);
         }
 
         if (!empty($posts['tags'][0])) {
             foreach ($posts['tags'] as $tag) {
-                $this->memoTagRepository->insertMemoTag($memoId, $tag);
+                $this->memoTagRepository->insertMemoTag($userId, $memoId, $tag);
             }
         }
     }

--- a/database/factories/MemoTagFactory.php
+++ b/database/factories/MemoTagFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\MemoTag;
 use App\Models\Memo;
 use App\Models\Tag;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class MemoTagFactory extends Factory
@@ -24,6 +25,7 @@ class MemoTagFactory extends Factory
     public function definition(): array
     {
         return [
+            'user_id' => User::factory(),
             'memo_id' => Memo::factory(),
             'tag_id' => Tag::factory(),
         ];

--- a/database/migrations/2022_01_16_044549_create_memos_table.php
+++ b/database/migrations/2022_01_16_044549_create_memos_table.php
@@ -19,8 +19,8 @@ class CreateMemosTable extends Migration
             $table->unsignedBigInteger('user_id');
             $table->softDeletes();
             
-            $table->timestamp('updated_at')->default(\DB::raw('CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP'));
             $table->timestamp('created_at')->default(\DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(\DB::raw('CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP'));
             $table->foreign('user_id')->references('id')->on('users');
         });
     }

--- a/database/migrations/2022_01_16_044725_create_tags_table.php
+++ b/database/migrations/2022_01_16_044725_create_tags_table.php
@@ -19,8 +19,8 @@ class CreateTagsTable extends Migration
             $table->unsignedBigInteger('user_id');
             $table->softDeletes();
 
-            $table->timestamp('updated_at')->default(\DB::raw('CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP'));
             $table->timestamp('created_at')->default(\DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(\DB::raw('CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP'));
             $table->foreign('user_id')->references('id')->on('users');
         });
     }

--- a/database/migrations/2022_01_16_044808_create_memo_tags_table.php
+++ b/database/migrations/2022_01_16_044808_create_memo_tags_table.php
@@ -14,11 +14,16 @@ class CreateMemoTagsTable extends Migration
     public function up()
     {
         Schema::create('memo_tags', function (Blueprint $table) {
+            $table->unsignedBigInteger('id', true);
+            $table->unsignedBigInteger('user_id');
             $table->unsignedBigInteger('memo_id');
             $table->unsignedBigInteger('tag_id');
+            $table->timestamp('created_at')->default(\DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(\DB::raw('CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP'));
 
             $table->foreign('memo_id')->references('id')->on('memos');
             $table->foreign('tag_id')->references('id')->on('tags');
+            $table->foreign('user_id')->references('id')->on('users');
         });
     }
 
@@ -29,6 +34,12 @@ class CreateMemoTagsTable extends Migration
      */
     public function down()
     {
+        Schema::table('memo_tags', function (Blueprint $table) {
+            $table->dropForeign(['memo_id']);
+            $table->dropForeign(['tag_id']);
+            $table->dropForeign(['user_id']);
+        });
+
         Schema::dropIfExists('memo_tags');
     }
 }

--- a/tests/Feature/HomeControllerTest.php
+++ b/tests/Feature/HomeControllerTest.php
@@ -267,7 +267,11 @@ class HomeControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $user->id]);
 
         foreach ($tags as $tag) {
-            MemoTag::factory()->create(['memo_id' => $memo->id, 'tag_id' => $tag->id]);
+            MemoTag::factory()->create([
+                'user_id' => $user->id,
+                'memo_id' => $memo->id,
+                'tag_id' => $tag->id,
+            ]);
         }
 
         $this->tagService->expects($this->once())
@@ -332,7 +336,11 @@ class HomeControllerTest extends TestCase
         $checkedTags = $tags->pluck('id')->toArray();
 
         foreach ($tags as $tag) {
-            MemoTag::factory()->create(['memo_id' => $memo->id, 'tag_id' => $tag->id]);
+            MemoTag::factory()->create([
+                'user_id' => $user->id,
+                'memo_id' => $memo->id,
+                'tag_id' => $tag->id,
+            ]);
         }
 
         $updatedContent = 'Updated memo content';
@@ -380,7 +388,11 @@ class HomeControllerTest extends TestCase
         $tags = Tag::factory()->count(3)->create(['user_id' => $user->id]);
 
         foreach ($tags as $tag) {
-            MemoTag::factory()->create(['memo_id' => $memo->id, 'tag_id' => $tag->id]);
+            MemoTag::factory()->create([
+                'user_id' => $user->id,
+                'memo_id' => $memo->id,
+                'tag_id' => $tag->id,
+            ]);
         }
 
         $updatedContent = 'Updated memo content';

--- a/tests/Unit/MemoRepositoryTest.php
+++ b/tests/Unit/MemoRepositoryTest.php
@@ -35,6 +35,7 @@ class MemoRepositoryTest extends TestCase
         $memo = Memo::factory()->create(['user_id' => $user->id]);
         $tag = Tag::factory()->create(['user_id' => $user->id]);
         $memoTag = MemoTag::factory()->create([
+            'user_id' => $user->id,
             'memo_id' => $memo->id,
             'tag_id' => $tag->id,
         ]);

--- a/tests/Unit/MemoServiceTest.php
+++ b/tests/Unit/MemoServiceTest.php
@@ -49,6 +49,7 @@ class MemoServiceTest extends TestCase
         $memo = Memo::factory()->create(['user_id' => $user->id]);
         $tag = Tag::factory()->create(['user_id' => $user->id]);
         MemoTag::factory()->create([
+            'user_id' => $user->id,
             'memo_id' => $memo->id,
             'tag_id' => $tag->id,
         ]);

--- a/tests/Unit/MemoTagRepositoryTest.php
+++ b/tests/Unit/MemoTagRepositoryTest.php
@@ -35,7 +35,7 @@ class MemoTagRepositoryTest extends TestCase
         $memo = Memo::factory()->create(['user_id' => $user->id]);
         $tag = Tag::factory()->create(['user_id' => $user->id]);
 
-        $this->memoTagRepository->insertMemoTag($memo->id, $tag->id);
+        $this->memoTagRepository->insertMemoTag($user->id, $memo->id, $tag->id);
 
         $this->assertDatabaseHas('memo_tags', [
             'memo_id' => $memo->id,
@@ -50,6 +50,7 @@ class MemoTagRepositoryTest extends TestCase
         $memo = Memo::factory()->create(['user_id' => $user->id]);
         $tag = Tag::factory()->create(['user_id' => $user->id]);
         MemoTag::factory()->create([
+            'user_id' => $user->id,
             'memo_id' => $memo->id,
             'tag_id' => $tag->id,
         ]);

--- a/tests/Unit/MemoTagServiceTest.php
+++ b/tests/Unit/MemoTagServiceTest.php
@@ -37,6 +37,7 @@ class MemoTagServiceTest extends TestCase
         $memo = Memo::factory()->create(['user_id' => $user->id]);
         $tag = Tag::factory()->create(['user_id' => $user->id]);
         MemoTag::factory()->create([
+            'user_id' => $user->id,
             'memo_id' => $memo->id,
             'tag_id' => $tag->id,
         ]);

--- a/tests/Unit/TagServiceTest.php
+++ b/tests/Unit/TagServiceTest.php
@@ -83,6 +83,7 @@ class TagServiceTest extends TestCase
         ]);
 
         MemoTag::factory()->create([
+            'user_id' => $user->id,
             'memo_id' => $memo->id,
             'tag_id' => $tag->id,
         ]);
@@ -113,6 +114,7 @@ class TagServiceTest extends TestCase
         MemoTag::factory()->create([
             'memo_id' => $memo->id,
             'tag_id' => $tag->id,
+            'user_id' => $user->id,
         ]);
 
         $post = [


### PR DESCRIPTION
<!-- このプルリクで何をしたのか？ -->
## 🛠️ やったこと
memo_tagsテーブルにカラムを追加

## ✅  動作確認
<!-- どのような動作確認が必要か（必要なければ「なし」で OK） -->
<!-- フロントの実装の場合は、できればbefore/afterを載せましょう -->
#### 準備

このブランチを取り込む前にAPPコンテナとテスト用コンテナでマイグレーションリセットを行う
```
php artisan migrate:reset
```
そのあと、APPコンテナとテスト用コンテナでマイグレーション実行する
```
php artisan migrate
```

#### アプリケーションテスト
新規メモ作成を行う際にタグも作成しDBを確認しmemo_tagsテーブルの`user_id`、`memo_id`、`tag_id`の値に誤りがないか

#### PHPUnit
全てのテストケースを実行
```
./vendor/bin/phpunit
```
