### PR TITLE
memo_tagsテーブルにdeleted_atカラムを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Webサービス機能一覧
 
 ## ER図
 
-![コメント 2022-01-30 135731](https://user-images.githubusercontent.com/93024617/151687277-3c48333a-a260-4e28-b752-72f0625468a3.png)
+![laravel-memo-app](https://github.com/a0dinw225/laravel-memo-app/assets/93024617/168b2366-b2fc-41e3-a4f2-d9fb2162d4e5)
 
 ## Requirement(要件)
 

--- a/database/migrations/2022_01_16_044808_create_memo_tags_table.php
+++ b/database/migrations/2022_01_16_044808_create_memo_tags_table.php
@@ -18,6 +18,7 @@ class CreateMemoTagsTable extends Migration
             $table->unsignedBigInteger('user_id');
             $table->unsignedBigInteger('memo_id');
             $table->unsignedBigInteger('tag_id');
+            $table->softDeletes();
             $table->timestamp('created_at')->default(\DB::raw('CURRENT_TIMESTAMP'));
             $table->timestamp('updated_at')->default(\DB::raw('CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP'));
 


### PR DESCRIPTION
<!-- PRの作成には時間をあまりかけないようにしましょう -->
<!-- PRの作成に時間がかかりそうな、複雑な場合は口頭連係で補いましょう -->

## 🛠️ やったこと
<!-- このプルリクで何をしたのか？ -->
- memo_tagsテーブルにdeleted_atカラムを追加
- READMEのER図を更新

## ✅  動作確認
<!-- どのような動作確認が必要か（必要なければ「なし」で OK） -->
<!-- フロントの実装の場合は、できればbefore/afterを載せましょう -->
このブランチ以外でマイグレーションリセットをAPPコンテナとテスト用コンテナで実行
```
php artisan migrate:reset
```

このブランチでマイグレーションをAPPコンテナとテスト用コンテナで実行
```
php artisan migrate
```

memo_tagsテーブルにdeleted_atカラムが追加されているか確認

## 🥺 その他（やらないことなど）
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
<!-- このプルリクでやらないことは何か？（やらない場合は、いつやるのかを明記する） -->
- 