### PR TITLE
メモ削除の修正

### DIFF
--- a/app/Repositories/MeMoTagRepository.php
+++ b/app/Repositories/MeMoTagRepository.php
@@ -20,6 +20,21 @@ class MemoTagRepository
     }
 
     /**
+     * get user memo with tag
+     *
+     * @param int $userId
+     * @param int $memoId
+     * @return array
+     */
+    public function getUserMemoWithTag(int $userId, int $memoId): array
+    {
+        return $this->memoTag::where([
+            'user_id' => $userId,
+            'memo_id' => $memoId,
+        ])->get()->toArray();
+    }
+
+    /**
      * insert memo tag
      *
      * @param int $userId
@@ -37,13 +52,18 @@ class MemoTagRepository
     }
 
     /**
-     * delete memo tag
+     * delete memo tag batch
      *
-     * @param int $memoId
+     * @param array $userIds
+     * @param array $memoIds
+     * @param array $tagIds
      * @return void
      */
-    public function deleteMemoTag(int $memoId): void
+    public function deleteMemoTagBatch(array $userIds, array $memoIds, array $tagIds): void
     {
-        $this->memoTag::where('memo_id', $memoId)->delete();
+        $this->memoTag::whereIn('user_id', $userIds)
+            ->whereIn('memo_id', $memoIds)
+            ->whereIn('tag_id', $tagIds)
+            ->update(['deleted_at' => now()]);
     }
 }

--- a/app/Repositories/MemoTagRepository.php
+++ b/app/Repositories/MemoTagRepository.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\MemoTag;
+
+class MemoTagRepository
+{
+    /** @var MemoTag */
+    protected $memoTag;
+
+    /**
+     * MemoTagRepository constructor.
+     *
+     * @param MemoTag $memoTag
+     */
+    public function __construct(MemoTag $memoTag)
+    {
+        $this->memoTag = $memoTag;
+    }
+
+    /**
+     * get user memo with tag
+     *
+     * @param int $userId
+     * @param int $memoId
+     * @return array
+     */
+    public function getUserMemoWithTag(int $userId, int $memoId): array
+    {
+        return $this->memoTag::where([
+            'user_id' => $userId,
+            'memo_id' => $memoId,
+        ])->get()->toArray();
+    }
+
+    /**
+     * insert memo tag
+     *
+     * @param int $userId
+     * @param int $memoId
+     * @param int $tagId
+     * @return void
+     */
+    public function insertMemoTag(int $userId, int $memoId, int $tagId): void
+    {
+        $this->memoTag::insert([
+            'user_id' => $userId,
+            'memo_id' => $memoId,
+            'tag_id' => $tagId,
+        ]);
+    }
+
+    /**
+     * delete memo tag batch
+     *
+     * @param array $userIds
+     * @param array $memoIds
+     * @param array $tagIds
+     * @return void
+     */
+    public function deleteMemoTagBatch(array $userIds, array $memoIds, array $tagIds): void
+    {
+        $this->memoTag::whereIn('user_id', $userIds)
+            ->whereIn('memo_id', $memoIds)
+            ->whereIn('tag_id', $tagIds)
+            ->update(['deleted_at' => now()]);
+    }
+}

--- a/app/Repositories/MemoTagRepositoryInterface.php
+++ b/app/Repositories/MemoTagRepositoryInterface.php
@@ -5,6 +5,15 @@ namespace App\Repositories;
 Interface MemoTagRepositoryInterface
 {
     /**
+     * Get user memos
+     *
+     * @param int $userId
+     * @param int $memoId
+     * @return array
+     */
+    public function getUserMemoWithTag(int $userId, int $memoId): array;
+
+    /**
      * insert memo tag
      *
      * @param int $userId
@@ -15,10 +24,12 @@ Interface MemoTagRepositoryInterface
     public function insertMemoTag(int $userId, int $memoId, int $tagId): void;
 
     /**
-     * delete memo tag
+     * delete memo tag batch
      *
-     * @param int $memoId
+     * @param array $userIds
+     * @param array $memoIds
+     * @param array $tagIds
      * @return void
      */
-    public function deleteMemoTag(int $memoId): void;
+    public function deleteMemoTagBatch(array $userIds, array $memoIds, array $tagIds): void;
 }

--- a/app/Services/MemoTagService.php
+++ b/app/Services/MemoTagService.php
@@ -20,13 +20,43 @@ class MemoTagService implements MemoTagServiceInterface
     }
 
     /**
+     * Get user memo with tag
+     *
+     * @param int $userId
+     * @param int $memoId
+     * @return array
+     */
+    public function getUserMemoWithTag(int $userId, int $memoId): array
+    {
+        return $this->memoTagRepository->getUserMemoWithTag($userId, $memoId);
+    }
+
+    /**
      * Delete memo tag
      *
-     * @param int $memoId
+     * @param array|null $memoWithTags
      * @return void
      */
-    public function deleteMemoTag(int $memoId): void
+    public function deleteMemoTag(?array $memoWithTags): void
     {
-        $this->memoTagRepository->deleteMemoTag($memoId);
+        if (is_null($memoWithTags)) {
+            return;
+        }
+
+        $batchSize = 100;
+
+        foreach (array_chunk($memoWithTags, $batchSize) as $memoWithTagBatch) {
+            $userIds = [];
+            $memoIds = [];
+            $tagIds = [];
+
+            foreach ($memoWithTagBatch as $memoWithTag) {
+                $userIds[] = $memoWithTag['user_id'];
+                $memoIds[] = $memoWithTag['memo_id'];
+                $tagIds[] = $memoWithTag['tag_id'];
+            }
+
+            $this->memoTagRepository->deleteMemoTagBatch($userIds, $memoIds, $tagIds);
+        }
     }
 }

--- a/app/Services/MemoTagServiceInterface.php
+++ b/app/Services/MemoTagServiceInterface.php
@@ -4,10 +4,19 @@ namespace App\Services;
 interface MemoTagServiceInterface
 {
     /**
+     * Get user memo with tag
+     *
+     * @param int $userId
+     * @param int $memoId
+     * @return array
+     */
+    public function getUserMemoWithTag(int $userId, int $memoId): array;
+
+    /**
      * Delete memo tag
      *
-     * @param int $memoId
+     * @param array|null $memoWithTags
      * @return void
      */
-    public function deleteMemoTag(int $memoId): void;
+    public function deleteMemoTag(?array $memoWithTags): void;
 }

--- a/public/js/confirm.js
+++ b/public/js/confirm.js
@@ -4,6 +4,6 @@ function deleteHandle(event) {
     if(window.confirm('本当に削除していいですか？')) {
         // 削除OKならformを再開
         document.getElementById('delete-form').submit();
-        alert('削除しました');
+        alert('削除します');
     }
 }

--- a/tests/Unit/MemoTagRepositoryTest.php
+++ b/tests/Unit/MemoTagRepositoryTest.php
@@ -82,4 +82,26 @@ class MemoTagRepositoryTest extends TestCase
             'tag_id' => $tag->id,
         ]);
     }
+
+    /** @test */
+    public function it_can_delete_memo_tag_batch(): void
+    {
+        $user = User::factory()->create();
+        $memo = Memo::factory()->create(['user_id' => $user->id]);
+        $tag = Tag::factory()->create(['user_id' => $user->id]);
+        MemoTag::factory()->create([
+            'user_id' => $user->id,
+            'memo_id' => $memo->id,
+            'tag_id' => $tag->id,
+        ]);
+
+        $this->memoTagRepository->deleteMemoTagBatch([$user->id], [$memo->id], [$tag->id]);
+
+        $this->assertDatabaseHas('memo_tags', [
+            'user_id' => $user->id,
+            'memo_id' => $memo->id,
+            'tag_id' => $tag->id,
+            'deleted_at' => now(),
+        ]);
+    }
 }

--- a/tests/Unit/MemoTagRepositoryTest.php
+++ b/tests/Unit/MemoTagRepositoryTest.php
@@ -29,6 +29,26 @@ class MemoTagRepositoryTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_user_memo_with_tag(): void
+    {
+        $user = User::factory()->create();
+        $memo = Memo::factory()->create(['user_id' => $user->id]);
+        $tag = Tag::factory()->create(['user_id' => $user->id]);
+        MemoTag::factory()->create([
+            'user_id' => $user->id,
+            'memo_id' => $memo->id,
+            'tag_id' => $tag->id,
+        ]);
+
+        $memoTags = $this->memoTagRepository->getUserMemoWithTag($user->id, $memo->id);
+
+        $this->assertCount(1, $memoTags);
+        $this->assertSame($user->id, $memoTags[0]['user_id']);
+        $this->assertSame($memo->id, $memoTags[0]['memo_id']);
+        $this->assertSame($tag->id, $memoTags[0]['tag_id']);
+    }
+
+    /** @test */
     public function it_can_insert_memo_tag(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/MemoTagRepositoryTest.php
+++ b/tests/Unit/MemoTagRepositoryTest.php
@@ -64,26 +64,6 @@ class MemoTagRepositoryTest extends TestCase
     }
 
     /** @test */
-    public function it_can_delete_memo_tag(): void
-    {
-        $user = User::factory()->create();
-        $memo = Memo::factory()->create(['user_id' => $user->id]);
-        $tag = Tag::factory()->create(['user_id' => $user->id]);
-        MemoTag::factory()->create([
-            'user_id' => $user->id,
-            'memo_id' => $memo->id,
-            'tag_id' => $tag->id,
-        ]);
-
-        $this->memoTagRepository->deleteMemoTag($memo->id);
-
-        $this->assertDatabaseMissing('memo_tags', [
-            'memo_id' => $memo->id,
-            'tag_id' => $tag->id,
-        ]);
-    }
-
-    /** @test */
     public function it_can_delete_memo_tag_batch(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/MemoTagServiceTest.php
+++ b/tests/Unit/MemoTagServiceTest.php
@@ -55,19 +55,27 @@ class MemoTagServiceTest extends TestCase
     {
         $user = User::factory()->create();
         $memo = Memo::factory()->create(['user_id' => $user->id]);
-        $tag = Tag::factory()->create(['user_id' => $user->id]);
-        MemoTag::factory()->create([
-            'user_id' => $user->id,
-            'memo_id' => $memo->id,
-            'tag_id' => $tag->id,
-        ]);
+        $tags = Tag::factory(3)->create(['user_id' => $user->id]);
+        foreach ($tags as $tag) {
+            MemoTag::factory()->create([
+                'user_id' => $user->id,
+                'memo_id' => $memo->id,
+                'tag_id' => $tag->id,
+            ]);
+        }
 
-        $this->memoTagService->deleteMemoTag($memo->id);
+        $memoTags = $this->memoTagService->getUserMemoWithTag($user->id, $memo->id);
+        $this->assertCount(3, $memoTags);
 
-        $this->assertDatabaseMissing('memo_tags', [
-            'memo_id' => $memo->id,
-            'tag_id' => $tag->id,
-        ]);
+        $this->memoTagService->deleteMemoTag($memoTags);
+
+        foreach ($memoTags as $memoTag) {
+            $this->assertDatabaseHas('memo_tags', [
+                'user_id' => $memoTag['user_id'],
+                'memo_id' => $memoTag['memo_id'],
+                'tag_id' => $memoTag['tag_id'],
+                'deleted_at' => now(),
+            ]);
+        }
     }
-
 }

--- a/tests/Unit/MemoTagServiceTest.php
+++ b/tests/Unit/MemoTagServiceTest.php
@@ -78,4 +78,11 @@ class MemoTagServiceTest extends TestCase
             ]);
         }
     }
+
+    /** @test */
+    public function it_can_delete_memo_tag_when_memo_with_tag_is_null(): void
+    {
+        $this->memoTagService->deleteMemoTag(null);
+        $this->assertTrue(true);
+    }
 }

--- a/tests/Unit/MemoTagServiceTest.php
+++ b/tests/Unit/MemoTagServiceTest.php
@@ -31,6 +31,26 @@ class MemoTagServiceTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_user_memo_with_tag(): void
+    {
+        $user = User::factory()->create();
+        $memo = Memo::factory()->create(['user_id' => $user->id]);
+        $tag = Tag::factory()->create(['user_id' => $user->id]);
+        MemoTag::factory()->create([
+            'user_id' => $user->id,
+            'memo_id' => $memo->id,
+            'tag_id' => $tag->id,
+        ]);
+
+        $memoTags = $this->memoTagService->getUserMemoWithTag($user->id, $memo->id);
+
+        $this->assertCount(1, $memoTags);
+        $this->assertSame($user->id, $memoTags[0]['user_id']);
+        $this->assertSame($memo->id, $memoTags[0]['memo_id']);
+        $this->assertSame($tag->id, $memoTags[0]['tag_id']);
+    }
+
+    /** @test */
     public function it_can_delete_memo_tag(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## 🛠️ やったこと
<!-- このプルリクで何をしたのか？ -->
- メモを削除する際に、メモとタグが紐づいているデータも削除した
- MeMoTagRepository.phpになっていたものをMemoTagRepository.phpに変更

## ✅  動作確認
<!-- どのような動作確認が必要か（必要なければ「なし」で OK） -->
<!-- フロントの実装の場合は、できればbefore/afterを載せましょう -->
#### 画面操作
メモに複数のタグを紐付け、メモを削除する
`memo_tags`テーブルでメモに紐づいているデータの`deleted_at`にタイムスタンプが入っているか

#### PHPUnit
テスト用コンテナで以下の追加削除されたテストを実行  
  
追加/変更したテストコード一覧
tests/Unit/MemoTagRepositoryTest.php:
```
it_can_get_user_memo_with_tag
it_can_delete_memo_tag_batch
```

app/Services/MemoTagService.php:
```
it_can_get_user_memo_with_tag
it_can_delete_memo_tag
it_can_delete_memo_tag_when_memo_with_tag_is_null
```



 