### PR TITLE
タグ削除機能(API実装)

### DIFF
--- a/app/Helpers/MemoHelper.php
+++ b/app/Helpers/MemoHelper.php
@@ -11,18 +11,23 @@ class MemoHelper
      *
      * @param object $memos
      * @param integer $tagId
-     * 
+     * @return string
      */
-    public static function displayMemos($memos, $tagId)
+    public static function displayMemos($memos, $tagId): string
     {
         if (is_null($memos) && is_null($tagId)) {
-            return;
+            return '';
         }
 
         if ($tagId && $memos->isEmpty()) {
             $tagName = self::getTagName($tagId);
-            $res = '関連づけられたメモがありません<br>';
-            $res .= "タグ名 : {$tagName} を<a href='#' onclick='deleteTag({$tagId}); return false;'>削除</a>";
+            $res = '<div class="alert alert-warning" role="alert">';
+            $res .= '関連づけられたメモがありません';
+            $res .= "</div>";
+            $res .= "<div class='text-center'>";
+            $res .= "<p>タグ名 : <strong>{$tagName}</strong></p>";
+            $res .= "<button class='btn btn-danger' onclick='deleteTag({$tagId}); return false;'>タグを削除</button>";
+            $res .= "</div>";
             return $res;
         }
 

--- a/app/Helpers/MemoHelper.php
+++ b/app/Helpers/MemoHelper.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Models\Tag;
+
+class MemoHelper
+{
+    /**
+     * Display memos
+     *
+     * @param object $memos
+     * @param integer $tagId
+     * 
+     */
+    public static function displayMemos($memos, $tagId)
+    {
+        if (is_null($memos) && is_null($tagId)) {
+            return;
+        }
+
+        if ($tagId && $memos->isEmpty()) {
+            $tagName = self::getTagName($tagId);
+            $res = '関連づけられたメモがありません<br>';
+            $res .= "タグ名 : {$tagName} を<a href='#' onclick='deleteTag({$tagId}); return false;'>削除</a>";
+            return $res;
+        }
+
+        $output = '';
+        foreach ($memos as $memo) {
+            $output .= '<a href="/edit/' . $memo['id'] . '" class="card-text d-block text-decoration-none elipsis mb-2">' . $memo['content'] . '</a>';
+        }
+
+        return $output;
+    }
+
+    /**
+     * Get tag name
+     *
+     * @param integer $tagId
+     * @return string
+     */
+    public static function getTagName($tagId): string
+    {
+        $tag = Tag::find($tagId);
+        return $tag ? $tag->name : '';
+    }
+}

--- a/app/Http/Controllers/Api/v1/TagController.php
+++ b/app/Http/Controllers/Api/v1/TagController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1;
+
+use \Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+use App\Services\TagServiceInterface;
+
+class TagController extends Controller
+{
+    /** @var TagServiceInterface */
+    protected $tagService;
+
+    /**
+     * TagController constructor.
+     *
+     * @param TagServiceInterface $tagService
+     */
+    
+    public function __construct(TagServiceInterface $tagService)
+    {
+        $this->middleware('auth:api');
+        $this->tagService = $tagService;
+    }
+
+    /**
+     * Delete tag
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function delete(Request $request): JsonResponse
+    {
+        try {
+            $tag = $this->tagService->getTagById($request->id);
+            $this->tagService->deleteTag($tag['id']);
+
+            return response()->json([
+                'message' => 'タグを削除しました',
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'タグの削除に失敗しました',
+            ], 500);
+        }
+    }
+}
+

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 
 class RegisterController extends Controller
 {
@@ -68,6 +69,7 @@ class RegisterController extends Controller
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
+            'api_token' => Str::random(80),
         ]);
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -46,12 +46,13 @@ class HomeController extends Controller
      * Show the application dashboard.
      * @return \Illuminate\Contracts\View\View
      */
-    public function index(): View
+    public function index(Request $request): View
     {
         $currentUserIdId = \Auth::id();
         $tags = $this->tagService->getUserTags($currentUserIdId);
+        $tagId = $request->query('tag');
 
-        return view('create', compact('tags'));
+        return view('create', compact('tags'), compact('tagId'));
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'api_token',
     ];
 
     /**

--- a/app/Repositories/TagRepository.php
+++ b/app/Repositories/TagRepository.php
@@ -20,6 +20,20 @@ class TagRepository implements TagRepositoryInterface
     }
 
     /**
+     * get tag by id
+     *
+     * @param int $tagId
+     * @return array
+     */
+    public function getTagById(int $tagId): array
+    {
+        return $this->tag::where('id', $tagId)
+                        ->whereNull('deleted_at')
+                        ->first()
+                        ->toArray();
+    }
+
+    /**
      * Get user tags
      *
      * @param int $userId
@@ -76,5 +90,18 @@ class TagRepository implements TagRepositoryInterface
     {
         return Tag::where('user_id', '=', $userId)->where('name', '=', $tagName)
         ->exists();
+    }
+
+    /**
+     * delete tag
+     *
+     * @param int $tagId
+     * @return void
+     */
+    public function deleteTag(int $tagId): void
+    {
+        Tag::where('id', $tagId)->update([
+            'deleted_at' => now(),
+        ]);
     }
 }

--- a/app/Repositories/TagRepositoryInterface.php
+++ b/app/Repositories/TagRepositoryInterface.php
@@ -5,6 +5,14 @@ namespace App\Repositories;
 interface TagRepositoryInterface
 {
     /**
+     * get tag by id
+     *
+     * @param int $tagId
+     * @return array
+     */
+    public function getTagById(int $tagId): array;
+
+    /**
      * Get user tags
      *
      * @param int $userId
@@ -38,4 +46,12 @@ interface TagRepositoryInterface
      * @return bool
      */
     public function checkTagExists(int $userId, ?string $tagName): bool;
+
+    /**
+     * delete tag
+     *
+     * @param int $tagId
+     * @return void
+     */
+    public function deleteTag(int $tagId): void;
 }

--- a/app/Services/TagService.php
+++ b/app/Services/TagService.php
@@ -19,6 +19,17 @@ class TagService implements TagServiceInterface
     }
 
     /**
+     * get tag by id
+     *
+     * @param int $tagId
+     * @return array
+     */
+    public function getTagById(int $tagId): array
+    {
+        return $this->tagRepository->getTagById($tagId);
+    }
+
+    /**
      * Get user tags
      *
      * @param int $userId
@@ -40,5 +51,16 @@ class TagService implements TagServiceInterface
     {
         $tagExists = $this->tagRepository->checkTagExists($userId, $tagName);
         return $tagExists;
+    }
+
+    /**
+     * Delete tag
+     *
+     * @param int $tagId
+     * @return void
+     */
+    public function deleteTag(int $tagId): void
+    {
+        $this->tagRepository->deleteTag($tagId);
     }
 }

--- a/app/Services/TagServiceInterface.php
+++ b/app/Services/TagServiceInterface.php
@@ -5,6 +5,14 @@ namespace App\Services;
 interface TagServiceInterface
 {
     /**
+     * get tag by id
+     *
+     * @param int $tagId
+     * @return array
+     */
+    public function getTagById(int $tagId): array;
+
+    /**
      * Get user tags
      *
      * @param int $userId

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/Helpers/MemoHelper.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/database/migrations/2023_05_15_154140_add_api_token_to_users_table.php
+++ b/database/migrations/2023_05_15_154140_add_api_token_to_users_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddApiTokenToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('api_token', 80)
+                ->after('password')
+                ->unique()
+                ->nullable()
+                ->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('api_token');
+        });
+    }
+}

--- a/public/js/deleteTag.js
+++ b/public/js/deleteTag.js
@@ -1,0 +1,25 @@
+function deleteTag(tagId) {
+  const apiToken = document.querySelector('meta[name="api-token"]').content;
+  if (confirm('本当に削除しますか？')) {
+    fetch(`/api/v1/tag/delete/${tagId}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + apiToken
+      },
+    })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Error: ' + response.statusText);
+      }
+      return response.json();
+    })
+    .then((data) => {
+      console.log('タグが削除されました。', data);
+      window.location.href = '/';
+    })
+    .catch((error) => {
+      console.error('Error:', error);
+    });
+  }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <!-- API Token -->
+    <meta name="api-token" content="{{ auth()->user()->api_token }}">
+
     <!-- CSRF Token -->
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
@@ -11,6 +14,7 @@
 
     <!-- Scripts -->
     <script src="{{ asset('js/app.js') }}" defer></script>
+    <script src="{{ asset('js/deleteTag.js') }}"></script>
     @yield('javascript')
     <!-- Fonts -->
     <link rel="dns-prefetch" href="//fonts.gstatic.com">
@@ -94,9 +98,7 @@
                     <div class="card">
                         <div class="card-header d-flex justify-content-between">メモ一覧<a href="{{ route('home') }}"><i class="fas fa-plus-circle"></i></a></div>
                         <div class="card-body my-card-body">
-                    @foreach($memos as $memo)
-                            <a href="/edit/{{$memo['id']}}" class="card-text d-block text-decoration-none elipsis mb-2">{{ $memo['content'] }}</a>
-                    @endforeach
+                            {!! App\Helpers\MemoHelper::displayMemos($memos, $tagId ?? null) !!}
                         </div>
                     </div>
                 </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\v1\TagController;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,4 +17,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
+});
+
+Route::middleware(['auth:api'])->prefix('v1')->name('api.v1.')->group(function () {
+    Route::delete('tag/delete/{id}', [TagController::class, 'delete'])->name('tag.delete');
 });

--- a/tests/Feature/Api/v1/TagControllerTest.php
+++ b/tests/Feature/Api/v1/TagControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Carbon\Carbon;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Tag;
+
+class TagControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_can_delete_a_tag()
+    {
+        $user = User::factory()->create();
+        $tag = Tag::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($user, 'api');
+
+        $response = $this->deleteJson(route('api.v1.tag.delete', ['id' => $tag->id]));
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'タグを削除しました',
+            ]);
+
+        $deleted_at = Carbon::parse(Tag::find($tag->id)->deleted_at)->format('Y-m-d H:i:s');
+
+        $this->assertDatabaseHas('tags', [
+            'id' => $tag->id,
+            'deleted_at' => $deleted_at,
+        ]);
+    }
+
+}
+

--- a/tests/Feature/HomeControllerTest.php
+++ b/tests/Feature/HomeControllerTest.php
@@ -68,6 +68,8 @@ class HomeControllerTest extends TestCase
             ->with($user->id)
             ->willReturn($tags->toArray());
 
+        Memo::factory()->count(3)->create(['user_id' => $user->id]);
+
         $response = $this->get(route('home'));
 
         $response->assertStatus(200)
@@ -85,6 +87,8 @@ class HomeControllerTest extends TestCase
             ->method('getUserTags')
             ->with($user->id)
             ->willReturn([]);
+
+        Memo::factory()->count(3)->create(['user_id' => $user->id]);
 
         $response = $this->get(route('home'));
 

--- a/tests/Unit/TagRepositoryTest.php
+++ b/tests/Unit/TagRepositoryTest.php
@@ -27,6 +27,17 @@ class TagRepositoryTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_tag_by_id(): void
+    {
+        $tag = Tag::factory()->create();
+
+        $result = $this->tagRepository->getTagById($tag->id);
+
+        $this->assertIsArray($result);
+        $this->assertSame($tag->id, $result['id']);
+    }
+
+    /** @test */
     public function it_can_get_user_tags(): void
     {
         $user = User::factory()->create();
@@ -108,5 +119,17 @@ class TagRepositoryTest extends TestCase
 
         $result = $this->tagRepository->checkTagExists($user->id, null);
         $this->assertFalse($result);
+    }
+
+    /** @test */
+    public function it_can_delete_tag(): void
+    {
+        $tag = Tag::factory()->create();
+
+        $this->tagRepository->deleteTag($tag->id);
+
+        $this->assertSoftDeleted('tags', [
+            'id' => $tag->id,
+        ]);
     }
 }

--- a/tests/Unit/TagServiceTest.php
+++ b/tests/Unit/TagServiceTest.php
@@ -30,6 +30,17 @@ class TagServiceTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_tag_by_id(): void
+    {
+        $tag = Tag::factory()->create();
+
+        $result = $this->tagService->getTagById($tag->id);
+
+        $this->assertIsArray($result);
+        $this->assertSame($tag->id, $result['id']);
+    }
+
+    /** @test */
     public function it_can_get_user_tags(): void
     {
         $user = User::factory()->create();
@@ -61,5 +72,17 @@ class TagServiceTest extends TestCase
         $result = $this->tagService->checkIfTagExists($user->id, null);
 
         $this->assertFalse($result);
+    }
+
+    /** @test */
+    public function it_can_delete_tag(): void
+    {
+        $tag = Tag::factory()->create();
+
+        $this->tagService->deleteTag($tag->id);
+
+        $this->assertSoftDeleted('tags', [
+            'id' => $tag->id,
+        ]);
     }
 }


### PR DESCRIPTION
## 🛠️ やったこと
<!-- このプルリクで何をしたのか？ -->
- メモに紐づいていないタグは削除できるようにした
- タグの削除はAPIにして実装
- `users`テーブルに`api_token`カラムを追加
- タグ削除のメソッド作成やテストコード作成
- その他、タグ削除機能の実装に伴い影響された既存メソッド / テストコードの修正

## ✅  動作確認
<!-- どのような動作確認が必要か（必要なければ「なし」で OK） -->
<!-- フロントの実装の場合は、できればbefore/afterを載せましょう -->
#### 前準備
APPコンテナとテスト用コンテナで以下のコマンドを実行
- `php artisan migrate`
- `composer dump-autoload`

以下の手順はAPPコンテナのみ
`php artisan tinker`
tinkerの中で以下のコードを実行
```
use Illuminate\Support\Str;
\App\Models\User::all()->each(function ($user) {
    $user->api_token = Str::random(80);
    $user->save();
});
```

#### 画面操作
以下の操作が正常に動作するか
・`/home`でメモ一覧にはすべてのメモが表示される
・メモにタグを紐づけて、タグ一覧からタグを押下しメモ一覧に紐付けたメモが表示される
・メモに紐づいているタグを解除し、タグ一覧から解除したタグを押下しメモ一覧からタグを削除できる

#### PHPUnit
追加 / 変更したテスケース一覧

tests/Unit/TagRepositoryTest.php
```
it_can_get_tag_by_id
it_can_delete_tag
```

tests/Unit/TagServiceTest.php
```
it_can_get_tag_by_id
it_can_delete_tag
```

tests/Feature/HomeControllerTest.php
```
it_can_show_the_application_dashboard
it_can_show_the_application_dashboard_with_no_tags
```

tests/Feature/Api/v1/TagControllerTest.php
```
it_can_delete_a_tag
```
