### PR TITLE
Xdebugインストール

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
+!.vscode/launch.json
 /.DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/var/www/html": "${workspaceFolder}"
+            },
+            "xdebugSettings": {
+                "max_children": 256,
+                "max_data": 1024,
+                "max_depth": 5,
+                "show_hidden": 1
+            }
+        },
+        {
+            "name": "Listen for Xdebug (Testing)",
+            "type": "php",
+            "request": "launch",
+            "port": 9004,
+            "pathMappings": {
+                "/var/www/html": "${workspaceFolder}"
+            },
+            "xdebugSettings": {
+                "max_children": 256,
+                "max_data": 1024,
+                "max_depth": 5,
+                "show_hidden": 1
+            }
+        },
+        {
+            "name": "Launch currently open script",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "port": 9003
+        }
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,25 @@
 FROM php:7.4-apache
 
+ARG XDEBUG_PORT=9003
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         libicu-dev \
         libonig-dev \
         libzip-dev \
+        libxml2-dev \
         git \
         && \
     docker-php-ext-install intl pdo_mysql zip && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
     a2enmod rewrite
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install xdebug-3.0.4 && \
+    docker-php-ext-enable xdebug && \
+    echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    echo "xdebug.client_port=${XDEBUG_PORT}" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 WORKDIR /var/www/html

--- a/README.md
+++ b/README.md
@@ -160,3 +160,21 @@ APPコンテナに入り、テストを行うと開発環境用DBのデータが
 ```
 ./vendor/bin/phpunit --filter it_can_get_user_memo_with_tags_by_id tests/Unit/MemoRepositoryTest.php
 ```
+
+## デバッグ前準備
+VS Codeの拡張機能「PHP Debug」をインストールする
+
+<img width="719" alt="スクリーンショット 2023-05-28 2 33 42" src="https://github.com/a0dinw225/laravel-memo-app/assets/93024617/4c38212b-8b4d-4426-8584-f93e24449a99">
+
+## デバッグ実行
+1. Webアプリでのデバッグ方法
+- ブレイクポイントを配置(ソースコード行数の左側を押下することで配置できる)
+- APPコンテナに入る
+- VS Codeのサイドバーから「実行とデバッグ」を選択し「Listen for Xdebug」を押下する。
+- Webアプリを操作しHTTPリクエストを送る
+
+2. PHPUnitでのデバッグ方法
+- ブレイクポイントを配置(ソースコード行数の左側を押下することで配置できる)
+- テスト用コンテナに入る
+- VS Codeのサイドバーから「実行とデバッグ」を選択し「Listen for Xdebug(Testing)」を押下する。
+- PHPUnitを実行する

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        XDEBUG_PORT: 9003
     container_name: myapp
     command: bash -c "php artisan serve --host=0.0.0.0"
     ports:
@@ -21,12 +23,15 @@ services:
       - DB_USERNAME=${DB_USERNAME}
       - DB_PASSWORD=${DB_PASSWORD}
       - TZ="Asia/Tokyo"
+      - XDEBUG_PORT=9003
     depends_on:
       - db
   app_testing:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        XDEBUG_PORT: 9004
     container_name: myapp_testing
     command: bash -c "php artisan serve --host=0.0.0.0"
     ports:
@@ -44,6 +49,7 @@ services:
       - DB_USERNAME=${DB_USERNAME}
       - DB_PASSWORD=${DB_PASSWORD}
       - TZ="Asia/Tokyo"
+      - XDEBUG_PORT=9004
     depends_on:
       - db
   db:


### PR DESCRIPTION
## 🛠️ やったこと
<!-- このプルリクで何をしたのか？ -->
- Xdebugのインストールのため`Dockerfile`、`docker-compose.yml`の修正や.`vscode/launch.json`を作成。

## ✅  動作確認
<!-- どのような動作確認が必要か（必要なければ「なし」で OK） -->
<!-- フロントの実装の場合は、できればbefore/afterを載せましょう -->
#### デバッグ構築
- Dockerコンテナとイメージを削除する
- ビルド、コンテナ起動する
```
docker-compose build
docker-compose up -d
```

- VS Codeの拡張機能「PHP Debug」をインストールする
<img width="719" alt="スクリーンショット 2023-05-28 2 33 42" src="https://github.com/a0dinw225/laravel-memo-app/assets/93024617/4c38212b-8b4d-4426-8584-f93e24449a99">

#### デバッグ実行
1. Webアプリでのデバッグ方法
- ブレイクポイントを配置(ソースコード行数の左側を押下することで配置できる)
- APPコンテナに入る
- VS Codeのサイドバーから「実行とデバッグ」を選択し「Listen for Xdebug」を押下する。
- Webアプリを操作しHTTPリクエストを送る

2. PHPUnitでのデバッグ方法
- ブレイクポイントを配置(ソースコード行数の左側を押下することで配置できる)
- テスト用コンテナに入る
- VS Codeのサイドバーから「実行とデバッグ」を選択し「Listen for Xdebug(Testing)」を押下する。
- PHPUnitを実行する